### PR TITLE
enable truncate_head param when using normal prompt (w/o demo)

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -582,6 +582,7 @@ class FewShotDataset(torch.utils.data.Dataset):
                 label_word_list=label_word_list,
                 first_sent_limit=self.args.first_sent_limit,
                 other_sent_limit=self.args.other_sent_limit,
+                truncate_head=self.args.truncate_head,
             )
             features = OurInputFeatures(**inputs, label=example_label)
 


### PR DESCRIPTION
The ``truncate_head`` param of ``tokenize_multipart_input`` function is not enabled, when call it for normal prompt tuning (i.e., w/o demonstration).
In fact, for some extreme long dataset, we have to manually truncate head instead of tail to avoid losing the template, even if we are not using demonstrations.